### PR TITLE
Use two queries to build monitor list

### DIFF
--- a/pkg/services/sqlstore/collector.go
+++ b/pkg/services/sqlstore/collector.go
@@ -120,7 +120,7 @@ func GetCollectorByName(query *m.GetCollectorByNameQuery) error {
 	result := results[0]
 
 	tags := make([]string, 0)
-	if result.Tags != "" {
+	if result.Tags != "" {
 		tags = strings.Split(result.Tags, ",")
 	}
 

--- a/pkg/services/sqlstore/monitor.go
+++ b/pkg/services/sqlstore/monitor.go
@@ -183,8 +183,15 @@ func GetMonitors(query *m.GetMonitorsQuery) error {
 	sess := x.Table("monitor")
 	rawParams := make([]interface{}, 0)
 	rawSql := `
+CREATE TEMPORARY TABLE colids 
+    (PRIMARY KEY(monitor_id))
+    SELECT 
+        GROUP_CONCAT(DISTINCT(monitor_collector.collector_id)) AS collector_ids,
+        monitor_id 
+    FROM monitor_collector 
+        GROUP BY monitor_id;
 SELECT
-    GROUP_CONCAT(DISTINCT(monitor_collector.collector_id)) as collector_ids,
+    colids.collector_ids,
     GROUP_CONCAT(DISTINCT(monitor_collector_tag.tag)) as collector_tags,
     GROUP_CONCAT(DISTINCT(collector_tag.collector_id)) as tag_collectors,
     endpoint.slug as endpoint_slug,

--- a/pkg/services/sqlstore/monitor.go
+++ b/pkg/services/sqlstore/monitor.go
@@ -49,7 +49,7 @@ type MonitorWithCollectorDTO struct {
 
 type CollectorIdsDTO struct {
 	CollectorIds string
-	MonitorId int64
+	MonitorId    int64
 }
 
 // scrutinizeState fixes the state.  We can't just trust what the database says, we have to verify that the value actually has been updated recently.

--- a/pkg/services/sqlstore/monitor.go
+++ b/pkg/services/sqlstore/monitor.go
@@ -183,6 +183,9 @@ WHERE monitor.enabled=1 AND (? % monitor.frequency) = monitor.offset
 
 func GetMonitors(query *m.GetMonitorsQuery) error {
 	sess := x.Table("monitor")
+	sess.IsAutoClose = false
+	defer sess.Close()
+
 	rawParams := make([]interface{}, 0)
 	tmpId := rand.Int63() & 0xFFFFFFFF
 	colidSql := fmt.Sprintf(`

--- a/pkg/services/sqlstore/monitor.go
+++ b/pkg/services/sqlstore/monitor.go
@@ -185,16 +185,16 @@ func GetMonitors(query *m.GetMonitorsQuery) error {
 	sess := x.Table("monitor")
 	rawParams := make([]interface{}, 0)
 	tmpId := rand.Int63() & 0xFFFFFFFF
-	colidSql := fmt.Printf(`
+	colidSql := fmt.Sprintf(`
 CREATE TEMPORARY TABLE colids%d 
     (PRIMARY KEY(monitor_id))
     SELECT 
         GROUP_CONCAT(DISTINCT(monitor_collector.collector_id)) AS collector_ids,
         monitor_id 
     FROM monitor_collector 
-        GROUP BY monitor_id`,tmpId)
+        GROUP BY monitor_id`, tmpId)
 
-	rawSql := fmt.Printf(`
+	rawSql := fmt.Sprintf(`
 SELECT
     colids%d.collector_ids,
     GROUP_CONCAT(DISTINCT(monitor_collector_tag.tag)) as collector_tags,
@@ -277,7 +277,7 @@ FROM monitor
 	if err != nil {
 		return err
 	}
-	err = sess.DropTable(fmt.Printf("colids%d", tmpId))
+	err = sess.DropTable(fmt.Sprintf("colids%d", tmpId))
 	if err != nil {
 		return err
 	}

--- a/pkg/services/sqlstore/monitor.go
+++ b/pkg/services/sqlstore/monitor.go
@@ -184,6 +184,7 @@ WHERE monitor.enabled=1 AND (? % monitor.frequency) = monitor.offset
 func GetMonitors(query *m.GetMonitorsQuery) error {
 	sess := x.Table("monitor")
 	sess.IsAutoClose = false
+	sess.AutoResetStatement = false
 	defer sess.Close()
 
 	rawParams := make([]interface{}, 0)

--- a/pkg/services/sqlstore/monitor.go
+++ b/pkg/services/sqlstore/monitor.go
@@ -271,7 +271,7 @@ FROM monitor
 	rawSql += " GROUP BY monitor.id"
 
 	result := make([]*MonitorWithCollectorDTO, 0)
-	colidResult := make([]*CollectorIdsDTO)
+	colidResult := make([]*CollectorIdsDTO, 0)
 
 	err := sess.Sql(colidSql).Find(&colidResult)
 	if err != nil {
@@ -294,8 +294,8 @@ FROM monitor
 		var monitorCollectorIds []int64
 		monitorCollectorsMap := make(map[int64]bool)
 		if val, ok := collectorIdList[row.Id]; ok {
-			cols := strings.Split(val.CollectorIds)
-			monitorCollectorIds = make(map[]int64, 0, len(cols))
+			cols := strings.Split(val, ",")
+			monitorCollectorIds = make([]int64, 0, len(cols))
 			for _, l := range cols {
 				i, err := strconv.ParseInt(l, 10, 64)
 				if err != nil {


### PR DESCRIPTION
The LEFT JOINs used to build the monitor list in `pkg/service/sqlstore/monitor.go` aren't entirely ideal, but while most of them don't impact performance at all yet (nor are real likely to soon), the LEFT JOIN of monitor_collector to monitor is hurting performance.

This PR breaks that query into two: one that queries the list of collector ids and their monitor_ids, grouped by monitor id, and the rest as it was before. The collector ids are then added to the monitor information struct.
