### PR TITLE
Update apiary.apib

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1,5 +1,5 @@
 FORMAT: 1A
-HOST: http://worldping-api.raintank.io/
+HOST: https://worldping-api.raintank.io/
 
 # worldPing API
 


### PR DESCRIPTION
Calls to the API over HTTP time-out; HTTPS is the correct protocol.
