### PR TITLE
build getProbeChecks query by hand

### DIFF
--- a/pkg/alerting/executor.go
+++ b/pkg/alerting/executor.go
@@ -73,7 +73,7 @@ func execute(job *m.AlertingJob, cache *lru.Cache) {
 	res, err := req.Query(setting.Alerting.GraphiteUrl+"render", headers)
 	executorJobQueryGraphite.Value(util.Since(preExec))
 	log.Debug("Alerting: job results - job:%v err:%v res:%v", job, err, res)
-
+	span.Finish()
 	if err != nil {
 		executorAlertOutcomesErr.Inc()
 		log.Error(3, "Alerting: query failed for job %q : %s", job, err.Error())


### PR DESCRIPTION
We now have so many checks that the existing query failed because
it exceeded the 2^16 limit for params in prepared statements