### PR TITLE
order probe_sessions by id

### DIFF
--- a/pkg/services/sqlstore/probe.go
+++ b/pkg/services/sqlstore/probe.go
@@ -636,7 +636,7 @@ func getProbeSessions(sess *session, probeId int64, instance string, since time.
 		sess.And("updated>?", since)
 	}
 	sessions := make([]m.ProbeSession, 0)
-	err := sess.OrderBy("updated").Find(&sessions)
+	err := sess.OrderBy("id").Find(&sessions)
 	return sessions, err
 }
 


### PR DESCRIPTION
When multiple sessions exist for the same probe_id, the check volume should be distributed between them.
When building the list of checks to assign to a probe, we first get the list of connected sessions.  it is expected that this list of sessions will be consistently orderd.  However the query to fetch the sessions orders them by 'updated' timestamp.  this leads to a race condition where the order of the sessions changes each time a session heartbeat is received. eg.

probeA -> sends heartbeat and 'updated' is set to 1
probeA starts refresh, active sessions are returned as [probeA, probeB]
probeB -> sends heartbeat and 'updated' is set to 10
probeB starts refresh, active sessions are returned as [probeB, probeA]

To ensure consistency, the probe_sessions should be orderd by their "id".